### PR TITLE
split interviews at long empty segments

### DIFF
--- a/markov_modelling/markov_utils.py
+++ b/markov_modelling/markov_utils.py
@@ -510,6 +510,23 @@ def estimate_pi_error(dtrajs, orig_msm, ntrails=10, conf_interval=0.68):
     return probabilities
 
 
+def consecutive(data, stepsize=1):
+    return np.split(data, np.where(np.diff(data) != stepsize)[0]+1)
+
+
+def split_interview(interview, max_gap=1):
+    all_empty_segments = consecutive(np.where(interview.sum(axis=1) == 0)[0])
+    empty_segs = [gap for gap in all_empty_segments if len(gap) > max_gap]
+
+    if len(empty_segs) > 0:
+        int_indices = np.arange(interview.shape[0])
+        int_indices = int_indices[~np.in1d(int_indices, np.concatenate(empty_segs))]
+        segment_index_list = consecutive(int_indices)
+        return [interview[idx] for idx in segment_index_list]
+    else:
+        return [interview]
+
+
 if __name__ == '__main__':
     pass
 

--- a/markov_modelling/test_msm.py
+++ b/markov_modelling/test_msm.py
@@ -3,7 +3,7 @@
 
 import numpy as np
 import pandas as pd
-import constants
+from . import constants
 from markov_modelling import markov_utils as mu
 from tqdm.auto import tqdm
 import json
@@ -126,6 +126,35 @@ class TestDiscreteTrajectories(unittest.TestCase):
 
             np.testing.assert_array_equal(is_empty_raw, is_empty_traj,
                                           err_msg=f'Empty state positions don`t match for IntCode {intcode}')
+    def test_interviewsplitter_simple(self):
+        interview = np.zeros((50, 100))  # 50 minutes, 100 topics
+        interview[np.arange(0, 10), 1] = 1
+        interview[np.arange(20, 35, 3), 3] = 1
+
+        si = mu.split_interview(interview, max_gap=3)
+        self.assertEqual(len(si), 2)
+        self.assertEqual(len(si[0]), 10)
+        self.assertEqual(si[0].sum(), 10)
+        self.assertEqual(len(si[1]), 13)  # removes last zero
+        self.assertEqual(si[1].sum(), 5)
+
+        si = mu.split_interview(interview, max_gap=1)
+        self.assertEqual(len(si), 6)
+        self.assertEqual(len(si[0]), 10)
+        self.assertEqual(si[0].sum(), 10)
+
+        for _si in si[1:]:
+            self.assertEqual(len(_si), 1)  # removes last zero
+            self.assertEqual(_si.sum(), 1)
+
+        interview = np.zeros((50, 100))  # 50 minutes, 100 topics
+        interview[:, 1] = 1
+        # interview[np.arange(20, 35, 3), 3] = 1
+
+        si = mu.split_interview(interview, max_gap=3)
+        self.assertEqual(len(si), 1)
+        self.assertTrue(np.all(si[0] == interview))
+
     '''
     def test_special_cases(self):
         #TODO: please complete test

--- a/markov_modelling/train_markov_model.py
+++ b/markov_modelling/train_markov_model.py
@@ -73,7 +73,9 @@ if __name__ == '__main__':
             # currently split if gap is longer than 2 minutes
             new_input_data_set = []
             for interview in input_data_set:
-                new_input_data_set += mu.split_interview(interview, max_gap=2)
+                _new_input_data_set = mu.split_interview(interview, max_gap=2)
+                # make sure to exclude single segments
+                new_input_data_set += [_int for _int in _new_input_data_set if len(_int) > 1]
             
             trajs = mu.estimate_fuzzy_trajectories(new_input_data_set)
             
@@ -118,12 +120,7 @@ if __name__ == '__main__':
 
 
             # Get the stationary distributions
-            
-
-            
             stationary_probs = mu.print_stationary_distributions(msm,df_active_states.KeywordLabel.to_list())
-            df_stationary_probs = pd.DataFrame(stationary_probs)
-            df_stationary_probs[df_stationary_probs.topic_name=="social bonds"]
 
             #pdb.set_trace()
             pd.DataFrame(stationary_probs).to_csv(output_directory+'/stationary_probs.csv')

--- a/markov_modelling/train_markov_model.py
+++ b/markov_modelling/train_markov_model.py
@@ -68,20 +68,12 @@ if __name__ == '__main__':
                 os.mkdir(output_directory)
             except:
                 pass
-           
-            # Estimate fuzzy trajectories
-            #empyt = [element[0] for element in input_data_set if element[0].sum()==0]
-            
 
-            new_input_data_set=[]
-            # Eliminate empty steps
+            # check input data for long empty segments and split interview there
+            # currently split if gap is longer than 2 minutes
+            new_input_data_set = []
             for interview in input_data_set:
-                new_interview = []
-                for row in interview:
-                    if row.sum()>0:
-                        new_interview.append(row)
-                new_input_data_set.append(np.vstack(new_interview))
-            input_data_set = new_input_data_set
+                new_input_data_set += mu.split_interview(interview, max_gap=2)
             
             trajs = mu.estimate_fuzzy_trajectories(new_input_data_set)
             


### PR DESCRIPTION
Some interviews have longer series of unassigned segments, i.e. it is not known what interviewees are discussing in this time. This PR splits interviews when there is such a gap in the input information to account for data sanity within the MSM framework. 